### PR TITLE
Fix CI build check to run on pull requests to main

### DIFF
--- a/.github/workflows/build_on_pull_request.yml
+++ b/.github/workflows/build_on_pull_request.yml
@@ -1,7 +1,7 @@
 name: Test Build  
 on: 
   pull_request:
-    branches: [ dev ]
+    branches: [ main ]
 
 jobs:
   deploy: 


### PR DESCRIPTION
## What changed
- The CI build check now runs on pull requests to the default branch.
- `build_on_pull_request.yml` triggers on `main` instead of the deleted `dev` branch.

## Why
- Self-found gap. The `Test Build` workflow triggers on `branches: [dev]`, but the repo's default branch is `main` and no `dev` branch exists.
- Dependabot PRs and any contributor PR to `main` therefore never get a build check.
- The build passes locally (`npm run build`), so the check would be green if it ran.

## How to verify
```sh
git fetch https://github.com/olitreadwell/sdvv-frontend.git fix/ci-build-check-on-main
git checkout FETCH_HEAD
npm ci
npm run build
```

---

**PROMOTION NOTE** (remove this section before/when opening against upstream):

```
gh pr create --repo opensandiego/sdvv-frontend --base main --head olitreadwell:fix/ci-build-check-on-main --title "Fix CI build check to run on pull requests to main"
```

Compare: https://github.com/opensandiego/sdvv-frontend/compare/main...olitreadwell:sdvv-frontend:fix/ci-build-check-on-main

Fork CI note: the build check passes; the Firebase preview job fails only because the fork lacks the upstream FIREBASE secrets.
